### PR TITLE
Don't trigger Observers and rewrite PathEntity.tick() for better performance

### DIFF
--- a/src/main/java/fr/lebon/autopath/blocks/PathBlock.java
+++ b/src/main/java/fr/lebon/autopath/blocks/PathBlock.java
@@ -22,6 +22,9 @@ public class PathBlock extends BlockWithEntity implements BlockEntityProvider, F
     public static final IntProperty STATE_RENDER = IntProperty.of("state_render",1,5);
     public static final BooleanProperty STEPPED = BooleanProperty.of("stepped");
 
+    /** setBlockState() flags that won't activate observers (and skips unnecessary lighting updates) */
+    public static final int SKIP_ALL_NEIGHBOR_AND_LIGHTING_UPDATES = Block.NOTIFY_LISTENERS | Block.FORCE_STATE | Block.SKIP_LIGHTING_UPDATES;
+
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
         stateManager.add(STEPPED);
@@ -54,7 +57,9 @@ public class PathBlock extends BlockWithEntity implements BlockEntityProvider, F
     @Override
     public void onSteppedOn(World world, BlockPos pos,BlockState state, Entity entity){
         if(!(world.isClient()) && entity.isAlive()){
-            world.setBlockState(pos, world.getBlockState(pos).with(STEPPED, true));
+            if (!state.get(STEPPED)) {
+                world.setBlockState(pos, state.with(STEPPED, true), SKIP_ALL_NEIGHBOR_AND_LIGHTING_UPDATES);
+            }
         }
     }
 
@@ -76,7 +81,7 @@ public class PathBlock extends BlockWithEntity implements BlockEntityProvider, F
      * We want the same behavior as GrassBlock so I copy paste Mojang code for grass block
      */
     public void grow(ServerWorld world, Random random, BlockPos pos, BlockState state) {
-       GrowRoutineGrassBlock.grow(world, random, pos, state, this);
+        GrowRoutineGrassBlock.grow(world, random, pos, state, this);
     }
 
 }

--- a/src/main/java/fr/lebon/autopath/mixin/BlockOnStepped.java
+++ b/src/main/java/fr/lebon/autopath/mixin/BlockOnStepped.java
@@ -1,5 +1,6 @@
 package fr.lebon.autopath.mixin;
 
+import fr.lebon.autopath.blocks.PathBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -19,7 +20,7 @@ public class BlockOnStepped {
 	@Inject(method = "onSteppedOn", cancellable = true, at = @At(value = "HEAD"))
     private void transformGrassToPathWhenSteppedOn(World world, BlockPos pos, BlockState state, Entity entity,CallbackInfo cir) {
         if(state.isOf(Blocks.GRASS_BLOCK) && (entity instanceof LivingEntity)){ //select grass and if entity is a mob or player
-            world.setBlockState(pos,AutoPath.PATH_BLOCK.getDefaultState()); //On remplace par un block path
+            world.setBlockState(pos,AutoPath.PATH_BLOCK.getDefaultState(), PathBlock.SKIP_ALL_NEIGHBOR_AND_LIGHTING_UPDATES); //On remplace par un block path
             cir.cancel();
         }
     }


### PR DESCRIPTION
As suspected in #32, the neighbor updates were indeed what triggered the Observers.
I missed that the `PathEntity` also changes the block state each tick, which took a while to figure out.

The fix for #32 was simply using
`world.setBlockState(pos, ..., Block.NOTIFY_LISTENERS | Block.FORCE_STATE);`
everywhere in `PathBlock` and `PathEntity`.

The default flags are `NOTIFY_LISTENERS` and `NOTIFY_NEIGHBORS`, so the above turns off the neighbor updates while `FORCE_STATE` turns off the "new style" neighbor updates - no idea what exactly that means, but we surely don't need or want them.
I also set the `SKIP_LIGHTING_UPDATES` flag as well, since the lighting won't change anyway.

While looking at `PathEntity.tick()` I noticed a lot of room for performance improvement because it calls `world.getBlockState()` and `world.setBlockState()` tons of times when there's no need to.

Since path can be everywhere and is constantly ticking, I took the time to rewrite it - it should be functionally identical the the previous version (except that I reordered it to "upgrade" before "downgrading" in the same tick).

Basically, instead of `world.getBlockState()`, the method parameter `state` is used and changed on the way along until it reaches the (singular) `world.setBlockState()` at the end.
A few other values are cached as well and I changed the `if` structure to not retest already known stuff.